### PR TITLE
feat: allow reusing external messages in generated handler

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/spaad_internal/src/lib.rs
+++ b/spaad_internal/src/lib.rs
@@ -120,7 +120,15 @@ pub fn entangled(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// #[spaad::handler]
-/// async fn do_something() {/* ... */}
+/// async fn do_something(&mut self) {/* ... */}
+///
+/// // will generate a message for you
+/// #[spaad::handler]
+/// async fn do_something(&mut self, str: String) {/* ... */}
+///
+/// // will reuse an existing message
+/// #[spaad::handler(msg = AMsg)]
+/// async fn do_something_with_a_msg(&mut self, msg: AMsg) {/* ... */}
 /// ```
 #[proc_macro_attribute]
 pub fn handler(_args: TokenStream, input: TokenStream) -> TokenStream {

--- a/spaad_internal/src/lib.rs
+++ b/spaad_internal/src/lib.rs
@@ -127,7 +127,7 @@ pub fn entangled(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// async fn do_something(&mut self, str: String) {/* ... */}
 ///
 /// // will reuse an existing message
-/// #[spaad::handler(msg = AMsg)]
+/// #[spaad::handler(msg = "AMsg")]
 /// async fn do_something_with_a_msg(&mut self, msg: AMsg) {/* ... */}
 /// ```
 #[proc_macro_attribute]


### PR DESCRIPTION
You can now do

```rust
#[spaad::handler(msg = "HandleEvent")]
pub async fn handle_event(&mut self, msg: HandleEvent) {
    unimplemented!();
}
```

feel free to squash merge