### PR TITLE
Use use instead of closure that only performs a rename

### DIFF
--- a/spaad_internal/src/entangle/transform.rs
+++ b/spaad_internal/src/entangle/transform.rs
@@ -452,7 +452,7 @@ fn transform_constructors(
         sig,
         ..
     } = method;
-    let is_name = |ty, name| ty_is_name(ty, name);
+    use self::ty_is_name as is_name;
 
     if matches!(
         &sig.output,


### PR DESCRIPTION
The prior solution was easy to cause borrow checker issues with smaller changes like addition of false || to the front.

It is also going to be broken by https://github.com/rust-lang/rust/pull/103293 . This PR is trying to fix the build failure in advance. Thus, ideally after a merge you would make a 0.4.1 release of the `spaad_internal` crate. Thanks!