### PR TITLE
Fix spaad_internal build error

### DIFF
--- a/spaad/Cargo.toml
+++ b/spaad/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["async", "actor", "futures", "async-await", "xtra"]
 categories = ["asynchronous", "concurrency"]
 
 [dependencies]
-spaad_internal = "0.4.0"
+spaad_internal = { version = "0.4.0", path = "../spaad_internal" }
 xtra = { version = "0.5.1", default-features = false }
 async-trait = { version = "^0.1" }
 

--- a/spaad_internal/src/entangle/transform.rs
+++ b/spaad_internal/src/entangle/transform.rs
@@ -454,9 +454,10 @@ fn transform_constructors(
     } = method;
     let is_name = |ty, name| ty_is_name(ty, name);
 
+    let name_string = name.to_string();
     if matches!(
         &sig.output,
-        ReturnType::Type(_, ty) if !(is_name(ty, &name.to_string()) || is_name(ty, "Self"))
+        ReturnType::Type(_, ty) if !(is_name(ty, &name_string) || is_name(ty, "Self"))
     ) {
         abort!(
             sig.output,


### PR DESCRIPTION
Fix build error:

```rust
   Compiling spaad_internal v0.4.0
error[E0716]: temporary value dropped while borrowed
   --> /home/adam/.cargo/registry/src/github.com-1ecc6299db9ec823/spaad_internal-0.4.0/src/entangle/transform.rs:459:51
    |
459 |         ReturnType::Type(_, ty) if !(is_name(ty, &name.to_string()) || is_name(ty, "Self"))
    |                                                   ^^^^^^^^^^^^^^^^-    ------- borrow later used here
    |                                                   |               |
    |                                                   |               temporary value is freed at the end of this statement
    |                                                   creates a temporary value which is freed while still in use
    |
help: consider using a `let` binding to create a longer lived value
    |
457 ~     let binding = name.to_string();
458 ~     if matches!(
459 |         &sig.output,
460 ~         ReturnType::Type(_, ty) if !(is_name(ty, &binding) || is_name(ty, "Self"))
    |

For more information about this error, try `rustc --explain E0716`.

```

Also, @Restioson  could you please publish a new version to crates.io after you merge this?